### PR TITLE
Optimize path output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 node_modules
 yarn-error.log
 .DS_Store
+.idea

--- a/src/path.ts
+++ b/src/path.ts
@@ -91,7 +91,7 @@ export function simplify(p: Path, threshold: number): Path {
 export function toSVG(p: Path): string {
   var coords: string[] = [];
   for (const path of p) {
-    coords.push(`${path.x},${path.y}`);
+    coords.push(`${ Math.round(path.x * 100) / 100 },${ Math.round(path.y * 100) / 100 }`);
   }
   let points = coords.join(" ");
   return `<polyline stroke="black" fill="none" points="${points}" />`;


### PR DESCRIPTION
Applying rounding to hundredths to reduce the file size of the output

Before:
![screen shot 2019-01-09 at 4 21 11 pm](https://user-images.githubusercontent.com/585833/50938317-855b9900-142c-11e9-8aab-cdbac6e29376.png)

After:
![screen shot 2019-01-09 at 4 32 22 pm](https://user-images.githubusercontent.com/585833/50938316-855b9900-142c-11e9-9569-a2e87cf3869f.png)

